### PR TITLE
Add Rackspace Cloud Load Balancer SSL Termination upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# Rackspace Python SDK
+.pyrax
+config.py

--- a/.pyrax-sample
+++ b/.pyrax-sample
@@ -1,0 +1,3 @@
+[rackspace_cloud]
+username = rackspace_username_here
+api_key = rackspace_api_key_here

--- a/config-sample.py
+++ b/config-sample.py
@@ -1,0 +1,15 @@
+# Rackspace configuration data
+rackspace = {
+    # CLB_IDS:
+    #
+    # Add an ID (or a list of space-seperated IDs) of the cloud
+    # load balancers you want to deploy generated certificates
+    # on to.
+    'CLB_IDS' : '',
+
+    # Port to use for SSL Traffic
+    'SECURE_PORT': 443,
+
+    # Whether to allow both HTTP and HTTPS (False) or only HTTPS (True)
+    'ALLOW_SECURE_TRAFFIC_ONLY' : False
+}


### PR DESCRIPTION
 After LetsEncrypt certificates have been generated via the Rackspace Cloud DNS API this addition will automatically take care of uploading the generated certificates via the Rackspace Cloud Load Balancers API.

This means that setting up, generating and installing SSL Termination on Rackspace Cloud Load Balancers can now be fully automated from the command line.